### PR TITLE
Fixes Build by getting rid of typos

### DIFF
--- a/OmniView.tex
+++ b/OmniView.tex
@@ -13,8 +13,6 @@
 }
 \makeglossaries
 
-%\tableofcontents
-\newpage 
 
 \begin{document}
 
@@ -54,7 +52,7 @@ The structure inside the epoch server that defines which channels are being send
 This list in combination with a checkbox will also be displayed in the view.
 
 \begin{figure}
-    \includegraphics[\width=.9\textwidth]{./assets/pictures/overview.pdf}
+    \includegraphics[width=.9\textwidth]{./assets/pictures/overview.pdf}
     \caption{Overview of Modules}
     \label{fig:Overview}
 \end{figure}


### PR DESCRIPTION
There were two minor bugs, that stopped the compilation. 
Should work again now. 

Please try compiling the document in the WSL with `pdflatex Omniview.tex` in order to find Bugs before pushing.